### PR TITLE
map acc req type to terms of account publication

### DIFF
--- a/src/itest/resources/json/input/company_profile_delta.json
+++ b/src/itest/resources/json/input/company_profile_delta.json
@@ -70,8 +70,7 @@
     "legal_form": "1",
     "credit_or_financial": "true",
     "acc_req_type": "1",
-    "business_activity": "testBusinessActivity",
-    "terms_of_account_publication": "1"
+    "business_activity": "testBusinessActivity"
   },
   "previous_company_names": [
     {

--- a/src/main/java/uk/gov/companieshouse/companyprofile/delta/mapper/CompanyProfileMapper.java
+++ b/src/main/java/uk/gov/companieshouse/companyprofile/delta/mapper/CompanyProfileMapper.java
@@ -62,6 +62,8 @@ public abstract class CompanyProfileMapper {
 
     @Mapping(target = "data.foreignCompanyDetails.accountingRequirement.foreignAccountType",
             source = "foreignCompany.accReqType")
+    @Mapping(target = "data.foreignCompanyDetails.accountingRequirement.termsOfAccountPublication",
+            source = "foreignCompany.accReqType")
 
     @Mapping(target = "data.foreignCompanyDetails.accounts.accountPeriodFrom.month",
             source = "foreignCompany.requiredToPublish.monthFrom")
@@ -373,7 +375,7 @@ public abstract class CompanyProfileMapper {
             ForeignCompanyDetails foreignCompanyDetails = data.getForeignCompanyDetails();
             if (foreignCompanyDetails.getAccountingRequirement() != null) {
                 AccountingRequirement accountingRequirement = foreignCompanyDetails.getAccountingRequirement();
-                String termsOfAccountPublication = source.getForeignCompany().getTermsOfAccountPublication();
+                String termsOfAccountPublication = source.getForeignCompany().getAccReqType();
 
                 HashMap<String,String> termsOfAccountPublicationMap = MapperUtils.getTermsOfAccountPublicationMap();
                 accountingRequirement.setTermsOfAccountPublication(termsOfAccountPublicationMap

--- a/src/test/java/uk/gov/companieshouse/companyprofile/delta/mapper/CompanyProfileMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/companyprofile/delta/mapper/CompanyProfileMapperTest.java
@@ -412,7 +412,7 @@ public class CompanyProfileMapperTest {
     }
 
     @Test
-    public void shouldMapForeignAccountTypeEnumToNull() throws IOException {
+    public void shouldMapAccountingRequirementToNullWhenAccReqTypeNull() throws IOException {
         setUpTestData("company-profile-delta-enumMapper-example.json", null);
         CompanyProfile resultProfile = companyProfileMapper.companyDeltaToCompanyProfile(companyDelta);
 
@@ -429,10 +429,7 @@ public class CompanyProfileMapperTest {
         expectedProfile.setData(expectedData);
 
         //compare values
-        assertEquals(expectedProfile.getData().getForeignCompanyDetails()
-                .getAccountingRequirement().getForeignAccountType(),
-                resultProfile.getData().getForeignCompanyDetails()
-                        .getAccountingRequirement().getForeignAccountType());
+        assertNull(resultProfile.getData().getForeignCompanyDetails().getAccountingRequirement());
     }
 
     @Test
@@ -490,12 +487,6 @@ public class CompanyProfileMapperTest {
         expectedProfile.setData(expectedData);
 
         assertEquals(expectedData.getForeignCompanyDetails().getAccounts(), resultProfile.getData().getForeignCompanyDetails().getAccounts());
-    }
-
-    @Test
-    public void shouldNotMapMustFileWithinWhenNull() throws IOException {
-        setUpTestData("company-profile-delta-empty-foreign-company-accounts.json", null);
-
     }
 
     @Test

--- a/src/test/resources/company-profile-delta-enumMapper-example.json
+++ b/src/test/resources/company-profile-delta-enumMapper-example.json
@@ -71,8 +71,7 @@
     "legal_form": "1",
     "credit_or_financial": "true",
     "acc_req_type": "",
-    "business_activity": "testBusinessActivity",
-    "terms_of_account_publication": "1"
+    "business_activity": "testBusinessActivity"
   },
   "previous_company_names": [
     {

--- a/src/test/resources/company-profile-delta-example.json
+++ b/src/test/resources/company-profile-delta-example.json
@@ -72,8 +72,7 @@
     "legal_form": "1",
     "credit_or_financial": "1",
     "acc_req_type": "1",
-    "business_activity": "testBusinessActivity",
-    "terms_of_account_publication": "1"
+    "business_activity": "testBusinessActivity"
   },
   "previous_company_names": [
     {

--- a/src/test/resources/company-profile-enumMapper-expected-output.json
+++ b/src/test/resources/company-profile-enumMapper-expected-output.json
@@ -45,10 +45,7 @@
     "etag" : null,
     "external_registration_number" : "12345",
     "foreign_company_details" : {
-        "accounting_requirement" : {
-            "foreign_account_type" : null,
-            "terms_of_account_publication" : "accounts-publication-date-supplied-by-company"
-        },
+        "accounting_requirement" : null,
         "accounts" : null,
         "business_activity" : "testBusinessActivity",
         "company_type" : "1",

--- a/src/test/resources/company-profile-expected-required-to-publish-output.json
+++ b/src/test/resources/company-profile-expected-required-to-publish-output.json
@@ -50,7 +50,7 @@
     "foreign_company_details" : {
         "accounting_requirement" : {
             "foreign_account_type" : "accounting-requirements-of-originating-country-apply",
-            "terms_of_account_publication" : null
+            "terms_of_account_publication" : "accounts-publication-date-supplied-by-company"
         },
         "accounts" : {
             "account_period_from" : {


### PR DESCRIPTION
- Map acc req type to terms of account publication.
- Update test files.
- Redo null test, as acc req type being null means Accounting Requirement has no populated fields and is therefore also null.