### PR TITLE
DSND-3109: Add delta at to delete delta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <ch-kafka.version>1.4.2</ch-kafka.version>
         <structured-logging.version>1.9.25</structured-logging.version>
         <kafka-models.version>1.0.34</kafka-models.version>
-        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.443</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
         <io-cucumber.version>7.2.3</io-cucumber.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>1.3.0</version>
+        <version>2.1.6</version>
     </parent>
     <artifactId>company-profile-delta-consumer</artifactId>
     <version>unversioned</version>
@@ -24,7 +24,7 @@
         <ch-kafka.version>1.4.2</ch-kafka.version>
         <structured-logging.version>1.9.25</structured-logging.version>
         <kafka-models.version>1.0.34</kafka-models.version>
-        <private-api-sdk-java.version>2.0.441</private-api-sdk-java.version>
+        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
         <io-cucumber.version>7.2.3</io-cucumber.version>

--- a/src/test/resources/company-profile-delete-delta-example.json
+++ b/src/test/resources/company-profile-delete-delta-example.json
@@ -1,5 +1,5 @@
 {
   "company_number": "1234",
   "action": "DELETE",
-  "delta_at": "delta_at"
+  "delta_at": "20230724093435661593"
 }

--- a/src/test/resources/company-profile-delete-delta-example.json
+++ b/src/test/resources/company-profile-delete-delta-example.json
@@ -1,4 +1,5 @@
 {
   "company_number": "1234",
-  "action": "DELETE"
+  "action": "DELETE",
+  "delta_at": "delta_at"
 }


### PR DESCRIPTION
This PR updates the tests to ensure the consumer can handle a delta_at field on an incoming delete delta.

[DSND-3109](https://companieshouse.atlassian.net/browse/DSND-3109)

[DSND-3109]: https://companieshouse.atlassian.net/browse/DSND-3109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ